### PR TITLE
Adiciona configurações para Impala

### DIFF
--- a/run_rllib.py
+++ b/run_rllib.py
@@ -35,6 +35,10 @@ if __name__ == "__main__":
     
     if agent == "PPO":
         trainer_config = ppo.DEFAULT_CONFIG.copy()
+        trainer_config['log_level'] = "WARN"
+        trainer_config['clip_rewards'] = True
+        trainer_config["num_gpus"] = 1
+        trainer_config['output'] = './checkpoints/' 
         trainer_config['num_workers'] = 0
         trainer_config["num_cpus_per_worker"] = 4
         trainer_config["num_envs_per_worker"] = 1
@@ -52,20 +56,6 @@ if __name__ == "__main__":
         trainer_config['framework'] = 'tf' if framework == "tf" else 'torch'
             
         agent = ppo.PPOTrainer(config=trainer_config, env=game)
-    elif agent == "APEXDQN":
-        trainer_config = dqn.apex.APEX_DEFAULT_CONFIG.copy()
-        trainer_config['log_level'] = "WARN"
-        trainer_config['clip_rewards'] = True
-        trainer_config["num_gpus"] = 1
-        trainer_config['output'] = './checkpoints/' 
-        trainer_config['target_network_update_freq'] = 20000
-        trainer_config["remote_worker_envs"] = True
-        trainer_config["num_workers"] = 4
-        trainer_config['num_envs_per_worker'] = 2
-        trainer_config['lr'] = .00005
-        trainer_config['train_batch_size'] = 64
-        trainer_config['gamma'] = 0.99
-        agent = dqn.apex.ApexTrainer(config=trainer_config, env=game)
     elif agent == "IMPALA":
         trainer_config = impala.DEFAULT_CONFIG.copy()
         trainer_config['log_level'] = "WARN"

--- a/run_rllib.py
+++ b/run_rllib.py
@@ -5,7 +5,7 @@ import retro
 from utils import retro_wrappers
 
 import ray
-from ray.rllib.agents.ppo import PPOTrainer, DEFAULT_CONFIG
+from ray.rllib.agents import ppo, impala
 from utils.rllib_utils import register_retro, train, test
 
 parser = argparse.ArgumentParser()
@@ -13,6 +13,8 @@ parser.add_argument("game", type=str)
 parser.add_argument("state", type=str)
 parser.add_argument("-c", "--checkpoint", type=str)
 parser.add_argument("-t", "--train", action="store_true")
+parser.add_argument("-a", "--agent", type=str, default="PPO")
+parser.add_argument("-f", "--framework", type=str, default="tf")
 parser.add_argument("-e", "--episodes", type=int, default=1)
 
 args = parser.parse_args()
@@ -23,35 +25,52 @@ if __name__ == "__main__":
     wrapper = retro_wrappers.get_wrapper(game)
     checkpoint = args.checkpoint
     training = args.train
+    agent = args.agent
+    framework = args.framework
     episode_count = args.episodes
 
     info = ray.init(ignore_reinit_error=True)
-
-    trainer_config = DEFAULT_CONFIG.copy()
-    trainer_config['log_level'] = "WARN"
-    trainer_config['framework'] = 'tf'
-    trainer_config['lambda'] = 0.95
-    trainer_config['kl_coeff'] = 0.5
-    trainer_config['clip_rewards'] = True
-    trainer_config['clip_param'] = 0.1
-    trainer_config['vf_clip_param'] = 10.0
-    trainer_config['entropy_coeff'] = 0.01
-    trainer_config['num_workers'] = 0
-    trainer_config["num_cpus_per_worker"] = 4
-    trainer_config["num_envs_per_worker"] = 1
-    trainer_config["num_gpus"] = 1
-    trainer_config["num_gpus_per_worker"] = 1
-    trainer_config["train_batch_size"] = 500
-    trainer_config['rollout_fragment_length'] = 100
-    trainer_config['sgd_minibatch_size'] = 128
-    trainer_config['num_sgd_iter'] = 10
-    trainer_config['batch_mode'] = "truncate_episodes"
-    trainer_config['observation_filter'] = "NoFilter"
-    trainer_config['model']['vf_share_layers'] = True
-    trainer_config['output'] = './checkpoints/'
-
+    
     register_retro(game, state, wrapper)
-    agent = PPOTrainer(config=trainer_config, env=game)
+    
+    if agent == "PPO":
+        trainer_config = ppo.DEFAULT_CONFIG.copy()
+        trainer_config['num_workers'] = 0
+        trainer_config["num_cpus_per_worker"] = 4
+        trainer_config["num_envs_per_worker"] = 1
+        trainer_config['lambda'] = 0.95
+        trainer_config['kl_coeff'] = 0.5
+        trainer_config['clip_param'] = 0.1
+        trainer_config['vf_clip_param'] = 10.0
+        trainer_config['entropy_coeff'] = 0.01
+        trainer_config["train_batch_size"] = 500
+        trainer_config['rollout_fragment_length'] = 100
+        trainer_config['sgd_minibatch_size'] = 128
+        trainer_config['num_sgd_iter'] = 10
+        trainer_config['batch_mode'] = "truncate_episodes"
+        trainer_config['observation_filter'] = "NoFilter"
+        agent = ppo.PPOTrainer(config=trainer_config, env=game)
+    elif agent == "IMPALA":
+        trainer_config = impala.DEFAULT_CONFIG.copy()
+        trainer_config['rollout_fragment_length'] = 20
+        trainer_config['train_batch_size'] = 32
+        trainer_config['num_envs_per_worker'] = 1
+        trainer_config['grad_clip'] = 40
+        trainer_config['momentum'] = 0.00
+        trainer_config['epsilon'] = 0.01
+        agent = impala.ImpalaTrainer(config=trainer_config, env=game)
+    
+    #Common parameters
+    trainer_config['log_level'] = "WARN"
+    trainer_config['clip_rewards'] = True
+    trainer_config["num_gpus"] = 1
+    
+    if framework == "torch": 
+        trainer_config['framework'] = 'torch'
+    else:
+        trainer_config['framework'] = 'tf'
+        
+    trainer_config['output'] = './checkpoints/'    
 
     if training:
         trainer = train(agent, checkpoint=checkpoint)

--- a/run_rllib.py
+++ b/run_rllib.py
@@ -52,12 +52,10 @@ if __name__ == "__main__":
         agent = ppo.PPOTrainer(config=trainer_config, env=game)
     elif agent == "IMPALA":
         trainer_config = impala.DEFAULT_CONFIG.copy()
-        trainer_config['rollout_fragment_length'] = 20
-        trainer_config['train_batch_size'] = 32
+        trainer_config['rollout_fragment_length'] = 50
+        trainer_config['train_batch_size'] = 500
+        trainer_config['num_workers'] = 8
         trainer_config['num_envs_per_worker'] = 1
-        trainer_config['grad_clip'] = 40
-        trainer_config['momentum'] = 0.00
-        trainer_config['epsilon'] = 0.01
         agent = impala.ImpalaTrainer(config=trainer_config, env=game)
     
     #Common parameters

--- a/run_rllib.py
+++ b/run_rllib.py
@@ -5,7 +5,7 @@ import retro
 from utils import retro_wrappers
 
 import ray
-from ray.rllib.agents import ppo, impala
+from ray.rllib.agents import ppo, impala, dqn
 from utils.rllib_utils import register_retro, train, test
 
 parser = argparse.ArgumentParser()
@@ -49,26 +49,41 @@ if __name__ == "__main__":
         trainer_config['num_sgd_iter'] = 10
         trainer_config['batch_mode'] = "truncate_episodes"
         trainer_config['observation_filter'] = "NoFilter"
+        trainer_config['framework'] = 'tf' if framework == "tf" else 'torch'
+            
         agent = ppo.PPOTrainer(config=trainer_config, env=game)
+    elif agent == "APEXDQN":
+        trainer_config = dqn.apex.APEX_DEFAULT_CONFIG.copy()
+        trainer_config['log_level'] = "WARN"
+        trainer_config['clip_rewards'] = True
+        trainer_config["num_gpus"] = 1
+        trainer_config['output'] = './checkpoints/' 
+        trainer_config['target_network_update_freq'] = 20000
+        trainer_config["remote_worker_envs"] = True
+        trainer_config["num_workers"] = 4
+        trainer_config['num_envs_per_worker'] = 2
+        trainer_config['lr'] = .00005
+        trainer_config['train_batch_size'] = 64
+        trainer_config['gamma'] = 0.99
+        agent = dqn.apex.ApexTrainer(config=trainer_config, env=game)
     elif agent == "IMPALA":
         trainer_config = impala.DEFAULT_CONFIG.copy()
+        trainer_config['log_level'] = "WARN"
+        trainer_config['clip_rewards'] = True
+        trainer_config["num_gpus"] = 1
+        trainer_config['output'] = './checkpoints/' 
         trainer_config['rollout_fragment_length'] = 50
         trainer_config['train_batch_size'] = 500
+        trainer_config["remote_worker_envs"] = True
         trainer_config['num_workers'] = 8
-        trainer_config['num_envs_per_worker'] = 1
-        agent = impala.ImpalaTrainer(config=trainer_config, env=game)
-    
-    #Common parameters
-    trainer_config['log_level'] = "WARN"
-    trainer_config['clip_rewards'] = True
-    trainer_config["num_gpus"] = 1
-    
-    if framework == "torch": 
-        trainer_config['framework'] = 'torch'
-    else:
-        trainer_config['framework'] = 'tf'
+        trainer_config['num_envs_per_worker'] = 4
+        trainer_config['lr_schedule'] = [           
+                [0, 0.0005],
+                [20000000, 0.000000000001],
+        ]
+        trainer_config['framework'] = 'tf' if framework == "tf" else 'torch'
         
-    trainer_config['output'] = './checkpoints/'    
+        agent = impala.ImpalaTrainer(config=trainer_config, env=game) 
 
     if training:
         trainer = train(agent, checkpoint=checkpoint)


### PR DESCRIPTION
Coloquei uma configuração meio padrão para o IMPALA, aproveitei e coloquei a configuração para o usuário escolher qual algoritmo usar (PPO ou IMPALA) no parser. Baseei os parâmetros do [paper](https://arxiv.org/pdf/1802.01561.pdf) apêndice G.

Deixei rodando por um tempo mas não obtive resultado muito bons :disappointed:. talvez tenha que ajustar workers ou alguma coisa de arquitetura assim. Os resultados foram piores que o PPO :disappointed:.